### PR TITLE
Update ScatterChart.tsx

### DIFF
--- a/src/components/chart-elements/ScatterChart/ScatterChart.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChart.tsx
@@ -137,8 +137,8 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
                 ticks={startEndOnly ? [data[0][x], data[data.length - 1][x]] : undefined}
                 type="number"
                 name={x}
-                // fill=""
-                // stroke=""
+                fill=""
+                stroke=""
                 className={tremorTwMerge(
                   // common
                   "text-tremor-label",


### PR DESCRIPTION
Uncomment the fill and stroke properties of the XAxis to enable the ability to change the color of the items within the X-axis.

<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**
Uncomment the fill and stroke properties of the XAxis to enable the ability to change the color of the items within the X-axis. This change allows the default color to be modified for the Y-axis but not for the X-axis of the chart.

**Related issue(s)**

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x<] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**

 tested the changes by modifying the default color for the Y-axis and confirming that it properly changes the color for the Y-axis but not for the X-axis.
